### PR TITLE
Adjust module UI styles

### DIFF
--- a/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
+++ b/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
@@ -114,7 +114,7 @@ export default function LessonPage({ params }: Props) {
 
   return (
     <AppLayout>
-      <div className="space-y-10 py-8">
+      <div className="space-y-14 py-12 md:space-y-20 md:py-16">
         <div>
           <Button variant="outline" asChild className="mb-6 text-sm">
             <Link href={`/modules/${module.slug}`}>
@@ -143,7 +143,7 @@ export default function LessonPage({ params }: Props) {
           )}
         </div>
 
-        <article className="prose prose-lg dark:prose-invert max-w-none space-y-8">
+        <article className="prose prose-lg dark:prose-invert max-w-none space-y-8 md:space-y-12">
           {isModule1Lesson1 ? (
             <>
               <p className="text-base italic text-muted-foreground">Beginner-friendly edition – no prior knowledge assumed</p>

--- a/src/app/modules/page.tsx
+++ b/src/app/modules/page.tsx
@@ -58,8 +58,8 @@ export default function ModulesPage() {
                   </CardDescription>
                 </CardContent>
                 <div className="p-6 pt-0">
-                  <Button asChild variant="outline" className="w-full">
-                    <Link href={`/modules/${module.slug}`}>View Module</Link>
+                  <Button asChild className="w-full bg-black text-white hover:bg-black/80">
+                    <Link href={`/modules/${module.slug}`}>Start</Link>
                   </Button>
                 </div>
               </Card>


### PR DESCRIPTION
## Summary
- update the module list button to use a black background and 'Start' text
- add extra spacing on lesson pages for readability

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684224bec6a48321a820205817c8f33a