### PR TITLE
Enhance lesson quiz modal

### DIFF
--- a/src/app/modules/[moduleSlug]/page.tsx
+++ b/src/app/modules/[moduleSlug]/page.tsx
@@ -5,7 +5,7 @@ import type { ModuleDefinition } from '@/types';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertTriangle, ChevronLeft, BookOpen, CheckCircle, HelpCircle } from 'lucide-react';
+import { AlertTriangle, ChevronLeft, BookOpen } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { Metadata, ResolvingMetadata } from 'next';
 
@@ -135,55 +135,6 @@ export default function ModuleDetailPage({ params }: Props) {
           )}
         </section>
 
-        {module.quiz && module.quiz.length > 0 && (
-           <section className="mt-12 pt-8 border-t border-border"> {/* Added mt-12 for separation */}
-            <h2 className="font-headline text-3xl font-semibold tracking-tight text-foreground mb-10 border-b pb-5">
-              Quiz
-            </h2>
-            <Card className="shadow-md rounded-xl overflow-hidden bg-card border border-border">
-              <CardHeader className="p-6">
-                <CardTitle className="text-xl font-semibold text-foreground">Test Your Knowledge</CardTitle>
-                <CardDescription className="text-base text-muted-foreground pt-1">
-                  Check your understanding of this module. ({module.quiz.length} {module.quiz.length === 1 ? 'question' : 'questions'})
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="p-6 pt-0 space-y-8">
-                {module.quiz.map((quizItem, index) => (
-                  <div key={index} className="p-6 border border-border rounded-lg bg-background shadow-sm space-y-4">
-                    <p className="font-medium text-lg text-foreground flex items-start">
-                        <HelpCircle className="h-5 w-5 text-primary mr-3 mt-1 flex-shrink-0" />
-                        <span>{index + 1}. {quizItem.question}</span>
-                    </p>
-                    {quizItem.options.length > 0 ? (
-                      <ul className="list-none space-y-2.5 pl-8">
-                        {quizItem.options.map((opt, i) => (
-                          <li key={i} className={`flex items-center text-muted-foreground ${opt.isCorrect ? 'font-medium text-foreground' : ''}`}>
-                            {opt.isCorrect ? <CheckCircle className="h-4 w-4 text-green-500 mr-2.5 flex-shrink-0" /> : <span className="h-4 w-4 mr-2.5 flex-shrink-0"></span>}
-                            <span>{String.fromCharCode(97 + i)}) {opt.text}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                       <p className="text-sm text-muted-foreground italic pl-8">Options not available for this question yet.</p>
-                    )}
-                    {quizItem.answerKey && !quizItem.options.some(o => o.isCorrect) && ( 
-                      <div className="mt-4 pt-4 border-t border-border">
-                        <p className="text-sm flex items-start">
-                          <CheckCircle className="h-4 w-4 text-primary mr-2.5 mt-0.5 flex-shrink-0" />
-                          <strong className="text-foreground mr-1.5">Answer:</strong> <span className="text-muted-foreground">{quizItem.answerKey}</span>
-                        </p>
-                      </div>
-                    )}
-                     {!quizItem.answerKey && !quizItem.options.some(o => o.isCorrect) && (
-                       <p className="text-sm mt-4 pt-4 border-t border-border text-muted-foreground italic pl-8">Answer key not provided for this question.</p>
-                    )}
-                  </div>
-                ))}
-                 <Button variant="outline" disabled className="mt-8 w-full sm:w-auto">Start Interactive Quiz (Coming Soon)</Button>
-              </CardContent>
-            </Card>
-          </section>
-        )}
       </div>
     </AppLayout>
   );

--- a/src/components/quiz-modal.tsx
+++ b/src/components/quiz-modal.tsx
@@ -1,7 +1,7 @@
-"use client"
+"use client";
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   Dialog,
   DialogTrigger,
@@ -10,47 +10,50 @@ import {
   DialogTitle,
   DialogDescription,
   DialogFooter,
-} from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
-import { Label } from '@/components/ui/label'
-import { Progress } from '@/components/ui/progress'
-import type { QuizQuestionDefinition } from '@/types'
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Check, X } from 'lucide-react';
+import type { QuizQuestionDefinition } from '@/types';
 
 interface QuizModalProps {
-  quiz: QuizQuestionDefinition[]
-  moduleSlug: string
+  quiz: QuizQuestionDefinition[];
+  moduleSlug: string;
 }
 
 export default function QuizModal({ quiz, moduleSlug }: QuizModalProps) {
-  const [open, setOpen] = useState(false)
-  const [index, setIndex] = useState(0)
-  const [choice, setChoice] = useState('')
-  const [score, setScore] = useState(0)
-  const router = useRouter()
+  const [open, setOpen] = useState(false);
+  const [index, setIndex] = useState(0);
+  const [choice, setChoice] = useState('');
+  const [score, setScore] = useState(0);
+  const router = useRouter();
 
-  const question = quiz[index]
-  const progress = Math.round((index / quiz.length) * 100)
+  const question = quiz[index];
+  const progress = Math.round((index / quiz.length) * 100);
 
   function handleNext() {
-    if (choice === '') return
-    const selected = parseInt(choice)
+    if (choice === '') return;
+    const selected = parseInt(choice);
     if (question.options[selected]?.isCorrect) {
-      setScore((s) => s + 1)
+      setScore((s) => s + 1);
     }
     if (index === quiz.length - 1) {
-      setOpen(false)
-      router.push(`/modules/${moduleSlug}`)
+      setOpen(false);
+      setIndex(0);
+      setChoice('');
+      router.push(`/modules/${moduleSlug}`);
     } else {
-      setIndex((i) => i + 1)
-      setChoice('')
+      setIndex((i) => i + 1);
+      setChoice('');
     }
   }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>Continue</Button>
+        <Button>Take Quiz</Button>
       </DialogTrigger>
       <DialogContent className="space-y-6">
         <DialogHeader>
@@ -62,12 +65,28 @@ export default function QuizModal({ quiz, moduleSlug }: QuizModalProps) {
         <div className="space-y-4">
           <p className="font-medium">{question.question}</p>
           <RadioGroup value={choice} onValueChange={setChoice} className="space-y-2">
-            {question.options.map((opt, i) => (
-              <div key={i} className="flex items-center space-x-2">
-                <RadioGroupItem id={`opt-${i}`} value={String(i)} />
-                <Label htmlFor={`opt-${i}`}>{opt.text}</Label>
-              </div>
-            ))}
+            {question.options.map((opt, i) => {
+              const selected = choice === String(i);
+              const correct = opt.isCorrect;
+              const highlight = selected
+                ? correct
+                  ? 'bg-green-100 text-green-800'
+                  : 'bg-red-100 text-red-800'
+                : '';
+              return (
+                <div
+                  key={i}
+                  className={`flex items-center space-x-2 rounded-md p-2 ${highlight}`}
+                >
+                  <RadioGroupItem id={`opt-${i}`} value={String(i)} />
+                  <Label htmlFor={`opt-${i}`} className="flex items-center space-x-2">
+                    {selected && correct && <Check className="h-4 w-4" />} 
+                    {selected && !correct && <X className="h-4 w-4" />}
+                    <span>{opt.text}</span>
+                  </Label>
+                </div>
+              );
+            })}
           </RadioGroup>
           <Progress value={progress} />
         </div>
@@ -76,5 +95,5 @@ export default function QuizModal({ quiz, moduleSlug }: QuizModalProps) {
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/src/lib/modules-data.ts
+++ b/src/lib/modules-data.ts
@@ -26,7 +26,24 @@ export const allModules: ModuleDefinition[] = [
         ],
         answerKey: 'b) Wick',
       },
-      // Add 4 more questions for Module 1 later
+      {
+        question: 'A long wick through a prior high usually indicates …',
+        options: [
+          { text: 'a lack of liquidity', isCorrect: false },
+          { text: 'a liquidity grab', isCorrect: true },
+          { text: 'market closed', isCorrect: false },
+        ],
+        answerKey: 'b) a liquidity grab',
+      },
+      {
+        question: 'The body of a candlestick shows …',
+        options: [
+          { text: 'where trading was most active', isCorrect: true },
+          { text: 'only the closing price', isCorrect: false },
+          { text: 'pending orders', isCorrect: false },
+        ],
+        answerKey: 'a) where trading was most active',
+      },
     ],
     imagePlaceholder: '/images/module-1-price-action.png', // Path confirmed
     dataAiHint: 'candlestick chart',
@@ -51,6 +68,24 @@ export const allModules: ModuleDefinition[] = [
           { text: 'no change', isCorrect: false },
         ],
         answerKey: 'b) probable reversal',
+      },
+      {
+        question: 'A Break of Structure (BOS) suggests …',
+        options: [
+          { text: 'trend continuation', isCorrect: true },
+          { text: 'immediate reversal', isCorrect: false },
+          { text: 'no movement', isCorrect: false },
+        ],
+        answerKey: 'a) trend continuation',
+      },
+      {
+        question: 'Liquidity pools often form near …',
+        options: [
+          { text: 'recent highs or lows', isCorrect: true },
+          { text: 'random mid-range levels', isCorrect: false },
+          { text: 'unrelated news articles', isCorrect: false },
+        ],
+        answerKey: 'a) recent highs or lows',
       },
     ],
     imagePlaceholder: '/images/module-2-price-action.png',
@@ -77,6 +112,24 @@ export const allModules: ModuleDefinition[] = [
           { text: 'all of the above', isCorrect: true },
         ],
         answerKey: 'd) all of the above',
+      },
+      {
+        question: 'A bullish order block forms before …',
+        options: [
+          { text: 'a down move', isCorrect: false },
+          { text: 'a strong up move', isCorrect: true },
+          { text: 'sideways price', isCorrect: false },
+        ],
+        answerKey: 'b) a strong up move',
+      },
+      {
+        question: 'After mitigation, price often …',
+        options: [
+          { text: 'continues in the original direction', isCorrect: true },
+          { text: 'reverses permanently', isCorrect: false },
+          { text: 'stops moving', isCorrect: false },
+        ],
+        answerKey: 'a) continues in the original direction',
       },
     ],
     imagePlaceholder: '/images/module-3-price-action.png',


### PR DESCRIPTION
## Summary
- expand quiz data with more questions
- improve quiz modal with feedback cues
- remove inline quiz from module pages

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae1a5d688321a892e080b37684ca