### PR TITLE
Add definitions to glossary search

### DIFF
--- a/src/lib/glossary-data.ts
+++ b/src/lib/glossary-data.ts
@@ -1,0 +1,21 @@
+import type { GlossaryTerm } from '@/types';
+
+export const glossaryData: GlossaryTerm[] = [
+  { term: 'Fibonacci Retracement', definition: 'Tool that applies Fibonacci ratios to measure potential pullback levels.' },
+  { term: 'Support and Resistance', definition: 'Price zones where buying or selling repeatedly halts further movement.' },
+  { term: 'Order Block', definition: 'A consolidation area where large orders accumulate, often acting as future support or resistance.' },
+  { term: 'Fair Value Gap', definition: 'A price imbalance or gap left when buying or selling overwhelms the other side.' },
+  { term: 'Liquidity Grab', definition: 'Quick sweep of resting orders above or below a range before reversing.' },
+  { term: 'Market Structure Shift', definition: 'Break of a significant swing high or low suggesting a potential trend change.' },
+  { term: 'Premium and Discount', definition: 'Concept describing price relative to a midpoint; premium is above, discount below.' },
+  { term: 'Time and Price Theory', definition: 'ICT idea that algorithmic price delivery aligns with specific times and price levels.' },
+  { term: 'ICT Killzones', definition: 'Key trading sessions like London or New York that offer higher-probability setups.' },
+  { term: 'Silver Bullet', definition: 'Intraday accumulation pattern leading to a sharp, quick move.' },
+  { term: 'Breaker Block', definition: 'Failed support or resistance that flips its role after a stop raid.' },
+  { term: 'Mitigation Block', definition: 'Candle where institutions offset previous orders, often providing a reaction area.' },
+  { term: 'Liquidity Void', definition: 'Rapid move with little trading activity that price may later revisit.' },
+  { term: 'Consolidation', definition: 'Sideways trading range where price moves within tight boundaries.' },
+  { term: 'Expansion', definition: 'Strong directional move breaking out of consolidation.' },
+  { term: 'Retracement', definition: 'Temporary counter-trend move before price resumes its direction.' },
+  { term: 'Reversal', definition: 'Complete change in trend direction.' },
+];


### PR DESCRIPTION
## Summary
- include glossary data with term definitions
- map definitions into search results
- display the definition next to each similarity score

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6844cbc25840832182919b28492328d2