### PR TITLE
Add dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
+import { ThemeProvider } from "@/hooks/use-theme";
 
 // If you want to use the Next.js font optimization, uncomment this:
 /*
@@ -30,8 +31,10 @@ export default function RootLayout({
       </head>
       {/* If using Next.js font optimization, use className={`${inter.variable} font-body antialiased`} */}
       <body className="font-body antialiased">
-        {children}
-        <Toaster />
+        <ThemeProvider>
+          {children}
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
-import { Search } from 'lucide-react';
+import { Moon, Search, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useTheme } from '@/hooks/use-theme';
 
 export default function Header() {
+  const { theme, toggleTheme } = useTheme();
   return (
     <header className="bg-background">
       <div className="container mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
@@ -23,6 +25,18 @@ export default function Header() {
         <nav className="flex items-center space-x-4">
           <Button variant="ghost" size="icon" aria-label="Search">
             <Search className="h-5 w-5 text-muted-foreground" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleTheme}
+            aria-label="Toggle Theme"
+          >
+            {theme === "dark" ? (
+              <Sun className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <Moon className="h-5 w-5 text-muted-foreground" />
+            )}
           </Button>
           <Button variant="secondary" className="rounded-full px-6 py-2 text-sm">
             Log in

--- a/src/hooks/use-theme.tsx
+++ b/src/hooks/use-theme.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+
+export type Theme = "light" | "dark"
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+  setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined)
+
+const STORAGE_KEY = "theme"
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = React.useState<Theme>("light")
+
+  React.useEffect(() => {
+    // Determine initial theme
+    let initial: Theme = "light"
+    if (typeof window !== "undefined") {
+      const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null
+      if (stored === "light" || stored === "dark") {
+        initial = stored
+      } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        initial = "dark"
+      }
+    }
+    setThemeState(initial)
+    document.documentElement.classList.toggle("dark", initial === "dark")
+  }, [])
+
+  const setTheme = React.useCallback((value: Theme) => {
+    setThemeState(value)
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, value)
+      document.documentElement.classList.toggle("dark", value === "dark")
+    }
+  }, [])
+
+  const toggleTheme = React.useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark")
+  }, [theme, setTheme])
+
+  const context = React.useMemo(
+    () => ({ theme, toggleTheme, setTheme }),
+    [theme, toggleTheme, setTheme]
+  )
+
+  return <ThemeContext.Provider value={context}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- create a theme context hook for light/dark mode
- wrap the app in `ThemeProvider`
- add theme toggle button in the header

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6844cbc8bbf08321881c8d60f4ca1802