### PR TITLE
Add progress tracking page

### DIFF
--- a/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
+++ b/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
@@ -17,6 +17,7 @@ import {
   MonitorPlay,
 } from "lucide-react";
 import QuizModal from "@/components/quiz-modal";
+import LessonProgress from "@/components/lesson-progress";
 import type { Metadata, ResolvingMetadata } from "next";
 
 type Props = {
@@ -178,6 +179,7 @@ export default function LessonPage({ params }: Props) {
 
   return (
     <AppLayout>
+      <LessonProgress id={`${module.slug}:${lesson.id}`} />
       <div className="space-y-14 py-12 md:space-y-20 md:py-16">
         <div>
           <Button variant="outline" asChild className="mb-6 text-sm">

--- a/src/app/progress/page.tsx
+++ b/src/app/progress/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+import AppLayout from '@/components/layout/app-layout'
+import { Progress as ProgressBar } from '@/components/ui/progress'
+import { allModules } from '@/lib/modules-data'
+import { useProgress } from '@/hooks/use-progress'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Progress | ICT Academy Lite' }
+
+export default function ProgressPage() {
+  const { progress } = useProgress()
+
+  const totalLessons = allModules.reduce((sum, m) => sum + m.lessons.length, 0)
+  const totalQuizzes = allModules.filter(m => m.quiz.length > 0).length
+  const total = totalLessons + totalQuizzes
+  const completed = progress.lessons.length + progress.quizzes.length
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100)
+
+  const lessonInfo = progress.lessons.map(id => {
+    const [mod, les] = id.split(':')
+    const module = allModules.find(m => m.slug === mod)
+    const lesson = module?.lessons.find(l => l.id === les)
+    return lesson ? `${module?.title.split('–')[1]?.trim() || module?.title} - ${lesson.title}` : id
+  })
+
+  return (
+    <AppLayout>
+      <div className="space-y-8">
+        <h1 className="font-headline text-3xl font-bold">Your Progress</h1>
+        <div>
+          <ProgressBar value={percent} />
+          <p className="mt-2 text-sm text-muted-foreground">{percent}% complete</p>
+        </div>
+        <div>
+          <h2 className="font-semibold text-xl mb-2">Completed Lessons</h2>
+          {lessonInfo.length > 0 ? (
+            <ul className="list-disc pl-5 space-y-1">
+              {lessonInfo.map(item => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-muted-foreground">No lessons completed yet.</p>
+          )}
+        </div>
+        <div>
+          <h2 className="font-semibold text-xl mb-2">Completed Quizzes</h2>
+          {progress.quizzes.length > 0 ? (
+            <ul className="list-disc pl-5 space-y-1">
+              {progress.quizzes.map(id => {
+                const module = allModules.find(m => m.slug === id)
+                const title = module?.title.split('–')[1]?.trim() || module?.title || id
+                return <li key={id}>{title}</li>
+              })}
+            </ul>
+          ) : (
+            <p className="text-muted-foreground">No quizzes completed yet.</p>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -21,6 +21,12 @@ export default function Header() {
           <span className="text-2xl font-semibold text-foreground">Core</span>
         </Link>
         <nav className="flex items-center space-x-4">
+          <Link
+            href="/progress"
+            className="text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Progress
+          </Link>
           <Button variant="ghost" size="icon" aria-label="Search">
             <Search className="h-5 w-5 text-muted-foreground" />
           </Button>

--- a/src/components/lesson-progress.tsx
+++ b/src/components/lesson-progress.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useEffect } from 'react'
+import { useProgress } from '@/hooks/use-progress'
+
+export default function LessonProgress({ id }: { id: string }) {
+  const { markLesson } = useProgress()
+  useEffect(() => {
+    if (id) markLesson(id)
+  }, [id, markLesson])
+  return null
+}

--- a/src/components/quiz-modal.tsx
+++ b/src/components/quiz-modal.tsx
@@ -17,6 +17,7 @@ import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Check, X } from 'lucide-react';
 import type { QuizQuestionDefinition } from '@/types';
+import { useProgress } from '@/hooks/use-progress';
 
 interface QuizModalProps {
   quiz: QuizQuestionDefinition[];
@@ -29,6 +30,7 @@ export default function QuizModal({ quiz, moduleSlug }: QuizModalProps) {
   const [choice, setChoice] = useState('');
   const [score, setScore] = useState(0);
   const router = useRouter();
+  const { markQuiz } = useProgress();
 
   const question = quiz[index];
   const progress = Math.round((index / quiz.length) * 100);
@@ -40,6 +42,7 @@ export default function QuizModal({ quiz, moduleSlug }: QuizModalProps) {
       setScore((s) => s + 1);
     }
     if (index === quiz.length - 1) {
+      markQuiz(moduleSlug);
       setOpen(false);
       setIndex(0);
       setChoice('');

--- a/src/hooks/use-progress.ts
+++ b/src/hooks/use-progress.ts
@@ -1,0 +1,53 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export interface ProgressData {
+  lessons: string[]
+  quizzes: string[]
+}
+
+const STORAGE_KEY = 'ict-progress'
+
+function readProgress(): ProgressData {
+  if (typeof window === 'undefined') return { lessons: [], quizzes: [] }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw) as ProgressData
+  } catch {}
+  return { lessons: [], quizzes: [] }
+}
+
+function writeProgress(data: ProgressData) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch {}
+}
+
+export function useProgress() {
+  const [progress, setProgress] = useState<ProgressData>({ lessons: [], quizzes: [] })
+
+  useEffect(() => {
+    setProgress(readProgress())
+  }, [])
+
+  const markLesson = (id: string) => {
+    setProgress(prev => {
+      if (prev.lessons.includes(id)) return prev
+      const updated = { ...prev, lessons: [...prev.lessons, id] }
+      writeProgress(updated)
+      return updated
+    })
+  }
+
+  const markQuiz = (id: string) => {
+    setProgress(prev => {
+      if (prev.quizzes.includes(id)) return prev
+      const updated = { ...prev, quizzes: [...prev.quizzes, id] }
+      writeProgress(updated)
+      return updated
+    })
+  }
+
+  return { progress, markLesson, markQuiz }
+}


### PR DESCRIPTION
## Summary
- track lesson and quiz completion in localStorage
- display progress with a new Progress page
- mark lessons and quizzes as completed when viewed
- link to Progress page in the header

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6844cbcfb1ec83219be211d7910fa648