### PR TITLE
Fix useTheme hook usage in Header

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import { Moon, Search, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## Summary
- mark `Header` component as a client component so `useTheme` hook runs correctly

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6844d1a99c548321ab2cedc01a954532