### PR TITLE
Add basic lint and typecheck workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+      - name: Run TypeScript typecheck
+        run: npm run typecheck


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and typecheck on PRs

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, @next/next/no-assign-module-variable)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6844d62745308321b8aa92516a1f3587