### PR TITLE
Fix compileMDX build error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  // Turbopack currently requires next-mdx-remote to be transpiled so
+  // that imports such as `next-mdx-remote/rsc` can be resolved.
+  // See https://github.com/hashicorp/next-mdx-remote for details.
+  transpilePackages: ['next-mdx-remote'],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- ensure `next-mdx-remote` is transpiled so `compileMDX` is available

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844e338d6288321973f7f9b4cf7179f