### PR TITLE
Fix MDX import for lessons

### DIFF
--- a/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
+++ b/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
@@ -21,6 +21,7 @@ import LessonProgress from "@/components/lesson-progress";
 import type { Metadata, ResolvingMetadata } from "next";
 import fs from "fs/promises";
 import path from "path";
+import { compileMDX } from "next-mdx-remote/rsc";
 
 export async function generateMetadata(
   { params }: any,
@@ -176,7 +177,6 @@ export default async function LessonPage({ params }: any) {
     );
     try {
       const source = await fs.readFile(filePath, 'utf8');
-      const { compileMDX } = await import('next-mdx-remote/rsc');
       const mdx = await compileMDX({
         source,
         components: { TermDefinitionTable, ComparisonTable },


### PR DESCRIPTION
## Summary
- import `compileMDX` at module scope
- call `compileMDX` directly instead of using a dynamic import

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844eed2460c8321af53cc50df4f04d5