### PR TITLE
Fix lesson titles and remove duplicate videos

### DIFF
--- a/src/app/modules/[moduleSlug]/page.tsx
+++ b/src/app/modules/[moduleSlug]/page.tsx
@@ -87,7 +87,7 @@ export default function ModuleDetailPage({ params }: any) {
         </header>
 
         <section className="mt-12"> {/* Added mt-12 for separation */}
-          <h2 className="font-headline text-3xl font-semibold tracking-tight text-foreground mb-10 border-b pb-5">
+          <h2 className="font-headline text-3xl font-bold tracking-tight text-foreground mb-10 border-b pb-5">
             Lessons
           </h2>
           {currentModule.lessons.length > 0 ? (
@@ -95,7 +95,7 @@ export default function ModuleDetailPage({ params }: any) {
               {currentModule.lessons.map((lesson, index) => (
                 <Card key={lesson.id} className="shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out rounded-xl overflow-hidden bg-card border border-border">
                   <CardHeader className="p-6">
-                    <CardTitle className="text-xl font-semibold text-foreground">
+                    <CardTitle className="text-xl font-bold text-foreground">
                       Lesson {index + 1}: {lesson.title}
                     </CardTitle>
                   </CardHeader>

--- a/src/content/modules/market-structure-liquidity/l3.mdx
+++ b/src/content/modules/market-structure-liquidity/l3.mdx
@@ -1,5 +1,3 @@
-<video src="/videos/m2_l3_sweeps.mp4" controls className="w-full rounded-md" />
-
 ## Module 2: Market Structure & Liquidity
 
 ### Lesson 3: Liquidity Sweeps

--- a/src/content/modules/order-blocks-mitigation/l1.mdx
+++ b/src/content/modules/order-blocks-mitigation/l1.mdx
@@ -1,5 +1,3 @@
-<video src="/videos/m3_l1_define_ob.mp4" controls className="w-full rounded-md" />
-
 ## Module 3: Order Blocks & Mitigation
 
 ### Lesson 1: Defining an Order Block

--- a/src/content/modules/price-action-foundations/l1.mdx
+++ b/src/content/modules/price-action-foundations/l1.mdx
@@ -1,5 +1,3 @@
-<video src="/videos/m1_l1_intro.mp4" controls className="w-full rounded-md" />
-
 ## Meet the Teacher: ICT
 
 Michael J. Huddleston, known as Inner Circle Trader (ICT), teaches that price moves to collect liquidity rather than follow indicators.


### PR DESCRIPTION
## Summary
- make lesson heading bold
- make lesson title text bold
- remove hardcoded videos from MDX lessons to prevent duplicates

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' etc.)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845949648c08321937df7e773ef7c5b