### PR TITLE
Add site 404 page and handle invalid slugs

### DIFF
--- a/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
+++ b/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
@@ -1,6 +1,5 @@
 import AppLayout from "@/components/layout/app-layout";
 import { allModules } from "@/lib/modules-data";
-import type { LessonDefinition, ModuleDefinition } from "@/types";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,12 +9,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  AlertTriangle,
-  ArrowLeft,
-  ChevronLeft,
-  MonitorPlay,
-} from "lucide-react";
+import { ChevronLeft, MonitorPlay } from "lucide-react";
+import { notFound } from "next/navigation";
 import QuizModal from "@/components/quiz-modal";
 import LessonProgress from "@/components/lesson-progress";
 import type { Metadata, ResolvingMetadata } from "next";
@@ -31,9 +26,7 @@ export async function generateMetadata(
   const lesson = currentModule?.lessons.find((l) => l.id === params.lessonId);
 
   if (!currentModule || !lesson) {
-    return {
-      title: "Lesson Not Found | ICT Academy Lite",
-    };
+    notFound();
   }
 
   return {
@@ -112,25 +105,7 @@ export default async function LessonPage({ params }: any) {
   const lesson = currentModule?.lessons.find((l) => l.id === params.lessonId);
 
   if (!currentModule || !lesson) {
-    return (
-      <AppLayout>
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <AlertTriangle className="h-16 w-16 text-destructive mb-4" />
-          <h1 className="text-3xl font-bold text-foreground mb-2">
-            Lesson Not Found
-          </h1>
-          <p className="text-muted-foreground mb-6">
-            Sorry, we couldn&apos;t find the lesson you were looking for.
-          </p>
-          <Button asChild variant="outline">
-            <Link href={`/modules/${params.moduleSlug || ""}`}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Module
-            </Link>
-          </Button>
-        </div>
-      </AppLayout>
-    );
+    notFound();
   }
 
 

--- a/src/app/modules/[moduleSlug]/page.tsx
+++ b/src/app/modules/[moduleSlug]/page.tsx
@@ -5,7 +5,8 @@ import type { ModuleDefinition } from '@/types';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertTriangle, ChevronLeft, BookOpen } from 'lucide-react';
+import { ChevronLeft, BookOpen } from 'lucide-react';
+import { notFound } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
 import type { Metadata, ResolvingMetadata } from 'next';
 
@@ -17,9 +18,7 @@ export async function generateMetadata(
   const currentModule = allModules.find((m) => m.slug === moduleSlug);
 
   if (!currentModule) {
-    return {
-      title: 'Module Not Found | ICT Academy Lite',
-    };
+    notFound();
   }
 
   const pageTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title;
@@ -39,23 +38,7 @@ export default function ModuleDetailPage({ params }: any) {
   const currentModule = allModules.find((m) => m.slug === params.moduleSlug);
 
   if (!currentModule) {
-    return (
-      <AppLayout>
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <AlertTriangle className="h-16 w-16 text-destructive mb-4" />
-          <h1 className="text-3xl font-bold text-foreground mb-2">Module Not Found</h1>
-          <p className="text-muted-foreground mb-6">
-            Sorry, we couldn&apos;t find the module you were looking for.
-          </p>
-          <Button asChild>
-            <Link href="/modules">
-              <ChevronLeft className="mr-2 h-4 w-4" />
-              Back to All Modules
-            </Link>
-          </Button>
-        </div>
-      </AppLayout>
-    );
+    notFound();
   }
 
   const displayTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import AppLayout from '@/components/layout/app-layout';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+
+export default function NotFound() {
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <AlertTriangle className="h-16 w-16 text-destructive mb-4" />
+        <h1 className="text-3xl font-bold text-foreground mb-2">Page Not Found</h1>
+        <p className="text-muted-foreground mb-6">
+          The page you are looking for doesn&apos;t exist or has been moved.
+        </p>
+        <div className="flex gap-4">
+          <Button asChild>
+            <Link href="/">Home</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/modules">Browse Modules</Link>
+          </Button>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add a global `not-found.tsx` page
- use `notFound()` for invalid module or lesson slugs

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594d5e5908321bdb483285280be6e