### PR TITLE
Add Jest tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -21,3 +21,5 @@ jobs:
         run: npm run lint
       - name: Run TypeScript typecheck
         run: npm run typecheck
+      - name: Run Jest tests
+        run: npm test


### PR DESCRIPTION
## Summary
- run tests in CI
- use Node.js v20 in CI

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: `TS1005` error)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594c2d9d88321880f749236744e1f