### PR TITLE
Fix client page hook usage

### DIFF
--- a/src/app/modules/page.tsx
+++ b/src/app/modules/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 
 import AppLayout from '@/components/layout/app-layout';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## Summary
- mark modules page as client component so `useRouter` works

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684598512adc83219f29bc5c27fe875c