### PR TITLE
Remove lesson headings

### DIFF
--- a/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
+++ b/src/app/modules/[moduleSlug]/[lessonId]/page.tsx
@@ -173,10 +173,6 @@ export default async function LessonPage({ params }: any) {
               Back to {currentModule.title.split("–")[1]?.trim() || currentModule.title}
             </Link>
           </Button>
-          <p className="text-sm font-medium text-primary mb-1">
-            {currentModule.title.split("–")[0]?.trim() || "Module"} - Lesson{" "}
-            {currentModule.lessons.findIndex((l) => l.id === lesson.id) + 1}
-          </p>
           <h1 className="font-headline text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
             {lesson.title}
           </h1>

--- a/src/content/modules/imbalances-fair-value-gaps/l1.mdx
+++ b/src/content/modules/imbalances-fair-value-gaps/l1.mdx
@@ -1,5 +1,3 @@
-## Lesson 1: Spotting the Imbalance
-
 When price moves aggressively in one direction it often leaves an **inefficient** area on the chart. ICT refers to this as an *imbalance* because buy and sell orders did not properly trade back and forth. The result is a section of candles with little or no overlap between their highs and lows.
 
 Why does this matter? Large institutions see these areas as unfinished business. They frequently pull price back to an imbalance to fill the missing orders before continuing in the original direction. Your first job is to learn to identify these fast moves so you know where the market may return.

--- a/src/content/modules/imbalances-fair-value-gaps/l2.mdx
+++ b/src/content/modules/imbalances-fair-value-gaps/l2.mdx
@@ -1,5 +1,3 @@
-## Lesson 2: The Fair Value Gap Concept
-
 A **Fair Value Gap (FVG)** is a specific type of imbalance. It is the range between the high of one candle and the low of a later candle when the middle candle trades so quickly that it leaves empty space. ICT teaches that these gaps represent inefficient pricing that the market often seeks to "rebalance."
 
 ```

--- a/src/content/modules/imbalances-fair-value-gaps/l3.mdx
+++ b/src/content/modules/imbalances-fair-value-gaps/l3.mdx
@@ -1,5 +1,3 @@
-## Lesson 3: Trading with FVGs
-
 Now that you can spot imbalances and fair value gaps, let's discuss how to use them in a trading plan. The core idea is that price often returns to an FVG before continuing. By anticipating that retracement, you can enter at a more favorable price.
 
 ### Basic Approach

--- a/src/content/modules/market-structure-liquidity/l1.mdx
+++ b/src/content/modules/market-structure-liquidity/l1.mdx
@@ -1,2 +1,1 @@
-## Lesson 1 Placeholder
 Content coming soon.

--- a/src/content/modules/market-structure-liquidity/l2.mdx
+++ b/src/content/modules/market-structure-liquidity/l2.mdx
@@ -1,2 +1,1 @@
-## Lesson 2 Placeholder
 Content coming soon.

--- a/src/content/modules/market-structure-liquidity/l3.mdx
+++ b/src/content/modules/market-structure-liquidity/l3.mdx
@@ -1,7 +1,3 @@
-## Module 2: Market Structure & Liquidity
-
-### Lesson 3: Liquidity Sweeps
-
 You've learned to see the market's skeleton (Structure) and identify its fuel (Liquidity). Now, it's time to put it all together. This lesson reveals how institutions actively use liquidity to engineer price moves, trap unsuspecting traders, and initiate their real campaigns. This is where you shift from being the prey to understanding the predator.
 
 **Objective:** By the end of this lesson, you will be able to identify a liquidity sweep (or stop hunt) and differentiate it from a true breakout, using it as a high-probability trade setup.

--- a/src/content/modules/order-blocks-mitigation/l1.mdx
+++ b/src/content/modules/order-blocks-mitigation/l1.mdx
@@ -1,7 +1,3 @@
-## Module 3: Order Blocks & Mitigation
-
-### Lesson 1: Defining an Order Block
-
 Welcome to the next level of your trading journey. So far, you've learned to read the broad currents of the market—the uptrends and downtrends that form the river of price. Now, we're going to zoom in. We're going to look for the deep, hidden pools where the largest creatures in the river—the institutional "whales"—leave their tracks.
 
 Think of yourself as a detective arriving at the scene of a major market event. There was a sudden, violent move. Your job isn't just to see that it happened; it's to find the clue that tells you why it happened and who was behind it. That clue, that critical piece of evidence left behind, is the Order Block.

--- a/src/content/modules/order-blocks-mitigation/l2.mdx
+++ b/src/content/modules/order-blocks-mitigation/l2.mdx
@@ -1,2 +1,1 @@
-## Lesson 2 Placeholder
 Content coming soon.

--- a/src/content/modules/order-blocks-mitigation/l3.mdx
+++ b/src/content/modules/order-blocks-mitigation/l3.mdx
@@ -1,2 +1,1 @@
-## Lesson 3 Placeholder
 Content coming soon.

--- a/src/content/modules/price-action-foundations/l2.mdx
+++ b/src/content/modules/price-action-foundations/l2.mdx
@@ -1,2 +1,1 @@
-## Lesson 2 Placeholder
 Content coming soon.

--- a/src/content/modules/price-action-foundations/l3.mdx
+++ b/src/content/modules/price-action-foundations/l3.mdx
@@ -1,2 +1,1 @@
-## Lesson 3 Placeholder
 Content coming soon.

--- a/src/content/modules/price-action-foundations/l4.mdx
+++ b/src/content/modules/price-action-foundations/l4.mdx
@@ -1,2 +1,1 @@
-## Lesson 4 Placeholder
 Content coming soon.

--- a/src/content/modules/price-action-foundations/l5.mdx
+++ b/src/content/modules/price-action-foundations/l5.mdx
@@ -1,2 +1,1 @@
-## Lesson 5 Placeholder
 Content coming soon.

--- a/src/content/modules/risk-management-performance-tracking/l1.mdx
+++ b/src/content/modules/risk-management-performance-tracking/l1.mdx
@@ -1,2 +1,1 @@
-## Lesson 1 Placeholder
 Content coming soon.

--- a/src/content/modules/risk-management-performance-tracking/l2.mdx
+++ b/src/content/modules/risk-management-performance-tracking/l2.mdx
@@ -1,2 +1,1 @@
-## Lesson 2 Placeholder
 Content coming soon.

--- a/src/content/modules/risk-management-performance-tracking/l3.mdx
+++ b/src/content/modules/risk-management-performance-tracking/l3.mdx
@@ -1,2 +1,1 @@
-## Lesson 3 Placeholder
 Content coming soon.

--- a/src/content/modules/trading-models-execution/l1.mdx
+++ b/src/content/modules/trading-models-execution/l1.mdx
@@ -1,2 +1,1 @@
-## Lesson 1 Placeholder
 Content coming soon.

--- a/src/content/modules/trading-models-execution/l2.mdx
+++ b/src/content/modules/trading-models-execution/l2.mdx
@@ -1,2 +1,1 @@
-## Lesson 2 Placeholder
 Content coming soon.

--- a/src/content/modules/trading-models-execution/l3.mdx
+++ b/src/content/modules/trading-models-execution/l3.mdx
@@ -1,2 +1,1 @@
-## Lesson 3 Placeholder
 Content coming soon.


### PR DESCRIPTION
## Summary
- clean up MDX lessons to remove duplicated heading text
- remove Module/Lesson label from lesson page

## Testing
- `npx next lint` *(fails: Need to install the following packages: next@15.3.3)*
- `npm run typecheck` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6845a0ae96108321bc88215bf99f2fa5