### PR TITLE
Switch progress hook to new Supabase client

### DIFF
--- a/src/hooks/use-progress.ts
+++ b/src/hooks/use-progress.ts
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { supabase } from '@/lib/supabase'
-import type { Session } from '@supabase/supabase-js'
+import { createClient } from '@/utils/supabase/client'
+import type { Session, SupabaseClient } from '@supabase/supabase-js'
 
 export interface ProgressData {
   lessons: string[]
@@ -29,6 +29,7 @@ function writeProgress(data: ProgressData) {
 export function useProgress() {
   const [progress, setProgress] = useState<ProgressData>({ lessons: [], quizzes: [] })
   const [session, setSession] = useState<Session | null>(null)
+  const supabase: SupabaseClient = createClient()
 
   useEffect(() => {
     setProgress(readProgress())


### PR DESCRIPTION
## Summary
- switch use-progress hook to use new browser Supabase client util

## Testing
- `npm run typecheck` *(fails: Cannot find module '@supabase/ssr' and others)*
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4937c648321b45c534595779162