### PR TITLE
Move lessons data to Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ User progress is stored in the Supabase `progress` table. Configure your
 Supabase credentials in `.env.local` using the variables
 `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
 
+To upload the module and lesson content to your database, run:
+
+```bash
+npm run seed
+```
+
 ## Building
 
 Generate a production build with:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "seed": "tsx scripts/seed-supabase.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",

--- a/scripts/seed-supabase.ts
+++ b/scripts/seed-supabase.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@supabase/supabase-js'
+import { allModules } from '../src/lib/modules-data'
+import fs from 'fs/promises'
+import path from 'path'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)
+
+async function run() {
+  for (const module of allModules) {
+    const { id, slug, title, level, description, imagePlaceholder, dataAiHint, quiz } = module
+    const { error } = await supabase
+      .from('modules')
+      .upsert({ id, slug, title, level, description, imagePlaceholder, dataAiHint, quiz }, { onConflict: 'id' })
+    if (error) console.error('module', slug, error.message)
+
+    for (const lesson of module.lessons) {
+      const filePath = path.join('src/content/modules', lesson.markdownPath ?? '')
+      let content = null
+      try {
+        content = await fs.readFile(filePath, 'utf8')
+      } catch {}
+      const { error: lessonError } = await supabase
+        .from('lessons')
+        .upsert(
+          {
+            id: lesson.id,
+            module_slug: slug,
+            title: lesson.title,
+            keyTakeaways: lesson.keyTakeaways,
+            videoUrl: lesson.videoUrl,
+            content
+          },
+          { onConflict: 'id,module_slug' }
+        )
+      if (lessonError) console.error('lesson', slug, lesson.id, lessonError.message)
+    }
+  }
+  console.log('Seeding complete')
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/modules/[moduleSlug]/page.tsx
+++ b/src/app/modules/[moduleSlug]/page.tsx
@@ -1,7 +1,6 @@
 
 import AppLayout from '@/components/layout/app-layout';
-import { allModules } from '@/lib/modules-data';
-import type { ModuleDefinition } from '@/types';
+import { fetchModule, fetchLessons, fetchModules } from '@/lib/supabase-content';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -14,35 +13,36 @@ export async function generateMetadata(
   { params }: any,
   _parent: ResolvingMetadata
 ): Promise<Metadata> {
-  const moduleSlug = params.moduleSlug;
-  const currentModule = allModules.find((m) => m.slug === moduleSlug);
+  const moduleSlug = params.moduleSlug
+  const currentModule = await fetchModule(moduleSlug)
 
   if (!currentModule) {
-    notFound();
+    notFound()
   }
 
-  const pageTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title;
+  const pageTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title
   return {
     title: `${pageTitle} | ICT Academy Lite`,
     description: currentModule.description,
-  };
+  }
 }
 
 export async function generateStaticParams() {
-  return allModules.map((mod) => ({
+  const modules = await fetchModules()
+  return modules.map((mod) => ({
     moduleSlug: mod.slug,
-  }));
+  }))
 }
 
-export default function ModuleDetailPage({ params }: any) {
-  const currentModule = allModules.find((m) => m.slug === params.moduleSlug);
-
+export default async function ModuleDetailPage({ params }: any) {
+  const currentModule = await fetchModule(params.moduleSlug)
   if (!currentModule) {
-    notFound();
+    notFound()
   }
+  const lessons = await fetchLessons(params.moduleSlug)
 
-  const displayTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title;
-  const moduleNumberString = currentModule.title.split('–')[0]?.trim();
+  const displayTitle = currentModule.title.split('–')[1]?.trim() || currentModule.title
+  const moduleNumberString = currentModule.title.split('–')[0]?.trim()
 
   return (
     <AppLayout>
@@ -73,9 +73,9 @@ export default function ModuleDetailPage({ params }: any) {
           <h2 className="font-headline text-3xl font-bold tracking-tight text-foreground mb-10 border-b pb-5">
             Lessons
           </h2>
-          {currentModule.lessons.length > 0 ? (
+          {lessons.length > 0 ? (
             <div className="space-y-8">
-              {currentModule.lessons.map((lesson, index) => (
+              {lessons.map((lesson, index) => (
                 <Card key={lesson.id} className="shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out rounded-xl overflow-hidden bg-card border border-border">
                   <CardHeader className="p-6">
                     <CardTitle className="text-xl font-bold text-foreground">

--- a/src/app/modules/client.tsx
+++ b/src/app/modules/client.tsx
@@ -6,9 +6,9 @@ import { Badge } from '@/components/ui/badge'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { allModules } from '@/lib/modules-data'
+import type { ModuleDefinition } from '@/types'
 
-export default function ModulesClient() {
+export default function ModulesClient({ modules }: { modules: ModuleDefinition[] }) {
   const router = useRouter()
   return (
     <section className="py-12 md:py-16">
@@ -23,7 +23,7 @@ export default function ModulesClient() {
         </div>
 
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {allModules.map((module, index) => (
+          {modules.map((module, index) => (
             <Card
               key={module.id}
               onClick={() => router.push(`/modules/${module.slug}`)}

--- a/src/app/modules/page.tsx
+++ b/src/app/modules/page.tsx
@@ -1,16 +1,18 @@
 import AppLayout from '@/components/layout/app-layout'
 import type { Metadata } from 'next'
 import ModulesClient from './client'
+import { fetchModules } from '@/lib/supabase-content'
 
 export const metadata: Metadata = {
   title: 'Modules | ICT Academy Lite',
   description: 'Explore our comprehensive ICT trading modules, from beginner to advanced.',
 }
 
-export default function ModulesPage() {
+export default async function ModulesPage() {
+  const modules = await fetchModules()
   return (
     <AppLayout>
-      <ModulesClient />
+      <ModulesClient modules={modules} />
     </AppLayout>
   )
 }

--- a/src/app/progress/client.tsx
+++ b/src/app/progress/client.tsx
@@ -1,21 +1,22 @@
 'use client'
 import { Progress as ProgressBar } from '@/components/ui/progress'
-import { allModules } from '@/lib/modules-data'
+import { useModules } from '@/hooks/use-modules'
 import { useProgress } from '@/hooks/use-progress'
 
 export default function ProgressClient() {
   const { progress } = useProgress()
+  const modules = useModules()
 
-  const totalLessons = allModules.reduce((sum, m) => sum + m.lessons.length, 0)
-  const totalQuizzes = allModules.filter(m => m.quiz.length > 0).length
+  const totalLessons = modules.reduce((sum, m) => sum + (m.lessons?.length || 0), 0)
+  const totalQuizzes = modules.filter(m => (m.quiz?.length || 0) > 0).length
   const total = totalLessons + totalQuizzes
   const completed = progress.lessons.length + progress.quizzes.length
   const percent = total === 0 ? 0 : Math.round((completed / total) * 100)
 
   const lessonInfo = progress.lessons.map(id => {
     const [mod, les] = id.split(':')
-    const currentModule = allModules.find(m => m.slug === mod)
-    const lesson = currentModule?.lessons.find(l => l.id === les)
+    const currentModule = modules.find(m => m.slug === mod)
+    const lesson = currentModule?.lessons?.find(l => l.id === les)
     return lesson ? `${currentModule?.title.split('–')[1]?.trim() || currentModule?.title} - ${lesson.title}` : id
   })
 
@@ -43,7 +44,7 @@ export default function ProgressClient() {
         {progress.quizzes.length > 0 ? (
           <ul className="list-disc pl-5 space-y-1">
             {progress.quizzes.map(id => {
-              const currentModule = allModules.find(m => m.slug === id)
+              const currentModule = modules.find(m => m.slug === id)
               const title = currentModule?.title.split('–')[1]?.trim() || currentModule?.title || id
               return <li key={id}>{title}</li>
             })}

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Award, Target, PlaySquare, FileQuestion, Users, ArrowRight, BookCopy } from 'lucide-react';
 import Image from 'next/image';
-import { allModules } from '@/lib/modules-data';
+import { useModules } from '@/hooks/use-modules';
 import { Badge } from '@/components/ui/badge';
 
 export default function HomeClient() {
@@ -53,7 +53,8 @@ export default function HomeClient() {
     },
   ];
 
-  const displayedModules = allModules.slice(0, 3);
+  const modules = useModules();
+  const displayedModules = modules.slice(0, 3);
 
   return (
     <AppLayout>

--- a/src/hooks/use-modules.ts
+++ b/src/hooks/use-modules.ts
@@ -1,0 +1,21 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { createClient } from '@/utils/supabase/client'
+import type { ModuleDefinition } from '@/types'
+
+export function useModules() {
+  const [modules, setModules] = useState<ModuleDefinition[]>([])
+
+  useEffect(() => {
+    const supabase = createClient()
+    supabase
+      .from('modules')
+      .select('id, slug, title, level, description, imagePlaceholder, dataAiHint, quiz')
+      .order('id')
+      .then(({ data }) => {
+        if (data) setModules(data as ModuleDefinition[])
+      })
+  }, [])
+
+  return modules
+}

--- a/src/lib/supabase-content.ts
+++ b/src/lib/supabase-content.ts
@@ -1,0 +1,46 @@
+import { createClient } from '@/utils/supabase/server'
+import type { ModuleDefinition, LessonDefinition } from '@/types'
+
+export async function fetchModules(): Promise<ModuleDefinition[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('modules')
+    .select('id, slug, title, level, description, imagePlaceholder, dataAiHint, quiz')
+    .order('id')
+  if (error) throw error
+  return data as ModuleDefinition[]
+}
+
+export async function fetchModule(slug: string): Promise<ModuleDefinition | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('modules')
+    .select('id, slug, title, level, description, imagePlaceholder, dataAiHint, quiz')
+    .eq('slug', slug)
+    .single()
+  if (error && error.code !== 'PGRST116') throw error
+  return (data as ModuleDefinition) || null
+}
+
+export async function fetchLessons(moduleSlug: string): Promise<LessonDefinition[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('lessons')
+    .select('id, title, keyTakeaways, videoUrl')
+    .eq('module_slug', moduleSlug)
+    .order('id')
+  if (error) throw error
+  return data as LessonDefinition[]
+}
+
+export async function fetchLessonContent(moduleSlug: string, lessonId: string): Promise<string | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('lessons')
+    .select('content')
+    .eq('module_slug', moduleSlug)
+    .eq('id', lessonId)
+    .single()
+  if (error) throw error
+  return data?.content ?? null
+}


### PR DESCRIPTION
## Summary
- seed script for Supabase
- fetch modules and lessons from the database
- use Supabase data on modules pages, lessons, home and progress pages
- add hook to load modules client side
- document seeding command

## Testing
- `npm run typecheck` *(fails: Cannot find module '@utils/supabase/client')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845b4f383a4832198f59a112f81c896