### PR TITLE
Fix Supabase import paths

### DIFF
--- a/src/hooks/use-modules.ts
+++ b/src/hooks/use-modules.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '../../utils/supabase/client'
 import type { ModuleDefinition } from '@/types'
 
 export function useModules() {

--- a/src/hooks/use-progress.ts
+++ b/src/hooks/use-progress.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '../../utils/supabase/client'
 import type { Session, SupabaseClient } from '@supabase/supabase-js'
 
 export interface ProgressData {

--- a/src/lib/supabase-content.ts
+++ b/src/lib/supabase-content.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/utils/supabase/server'
+import { createClient } from '../../utils/supabase/server'
 import type { ModuleDefinition, LessonDefinition } from '@/types'
 
 export async function fetchModules(): Promise<ModuleDefinition[]> {


### PR DESCRIPTION
## Summary
- update hooks and lib to use relative imports for supabase utils

## Testing
- `npm run typecheck` *(fails: Property 'catch' does not exist on type)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845ba0ef2b08321a6f7ffac19c44ae7