### PR TITLE
Add utils alias

### DIFF
--- a/src/hooks/use-modules.ts
+++ b/src/hooks/use-modules.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '@utils/supabase/client'
 import type { ModuleDefinition } from '@/types'
 
 export function useModules() {

--- a/src/hooks/use-progress.ts
+++ b/src/hooks/use-progress.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '@utils/supabase/client'
 import type { Session, SupabaseClient } from '@supabase/supabase-js'
 
 export interface ProgressData {

--- a/src/lib/supabase-content.ts
+++ b/src/lib/supabase-content.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/utils/supabase/server'
+import { createClient } from '@utils/supabase/server'
 import type { ModuleDefinition, LessonDefinition } from '@/types'
 
 export async function fetchModules(): Promise<ModuleDefinition[]> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@utils/*": ["./utils/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- extend the `tsconfig.json` paths with `@utils/*` alias
- point supabase hooks and helper to the new alias
- run `npm run typecheck` and `npm run lint`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2140a6c83219a403838fba05538