### PR TITLE
Fix undefined cookie store

### DIFF
--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,7 +1,9 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const createClient = (cookieStore: ReturnType<typeof cookies>) => {
+export const createClient = (
+  cookieStore: ReturnType<typeof cookies> = cookies(),
+) => {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,


### PR DESCRIPTION
## Summary
- ensure the server-side Supabase client defaults to using `next/headers` cookies if none are provided

## Testing
- `npm run typecheck` *(fails: Could not find a declaration file for module 'next', etc.)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f2a6af88832198072f0272e190e9