### PR TITLE
Fix cookies call context

### DIFF
--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -2,20 +2,21 @@ import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
 export const createClient = (
-  cookieStore: ReturnType<typeof cookies> = cookies(),
+  cookieStore?: ReturnType<typeof cookies>,
 ) => {
+  const store = cookieStore ?? cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         getAll() {
-          return cookieStore.getAll();
+          return store.getAll();
         },
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              store.set(name, value, options)
             );
           } catch {
             // The `setAll` method was called from a Server Component.


### PR DESCRIPTION
## Summary
- adjust Supabase server helper so `cookies()` is not called at module scope

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find Next modules)*

------
https://chatgpt.com/codex/tasks/task_e_6845f883ca708321a65669b6c1e23886