### PR TITLE
Fix supabase client cookies usage

### DIFF
--- a/src/hooks/use-progress.ts
+++ b/src/hooks/use-progress.ts
@@ -76,7 +76,10 @@ export function useProgress() {
           .from('progress')
           .update({ lessons: updated.lessons })
           .eq('user_id', session.user.id)
-          .catch(() => {})
+          .then(
+            () => {},
+            () => {}
+          )
       }
       return updated
     })
@@ -92,7 +95,10 @@ export function useProgress() {
           .from('progress')
           .update({ quizzes: updated.quizzes })
           .eq('user_id', session.user.id)
-          .catch(() => {})
+          .then(
+            () => {},
+            () => {}
+          )
       }
       return updated
     })

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,10 +1,18 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+const safeCookies = () => {
+  try {
+    return cookies();
+  } catch {
+    return { getAll: () => [], set: () => {} };
+  }
+};
+
 export const createClient = (
-  cookieStore?: ReturnType<typeof cookies>,
+  cookieStore?: ReturnType<typeof cookies> | any,
 ) => {
-  const store = cookieStore ?? cookies();
+  const store: any = cookieStore ?? safeCookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,


### PR DESCRIPTION
## Summary
- avoid calling `cookies()` outside of request context
- fix supabase progress hooks to use proper promise API

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845f9ec6e308321b8868aa357b76dbd